### PR TITLE
Debug mode switch to prevent IO error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 .DS_Store
+.idea


### PR DESCRIPTION
A call to `puts` inside `RoomoramaApi::Client#api_call` causes an IO error when running in a daemonized Resque worker: 

```
Input/output error - <STDOUT>
/var/www/app_staging/shared/bundle/ruby/1.9.1/gems/roomorama_api-0.3.0/lib/roomorama_api.rb:43:in `write'
/var/www/app_staging/shared/bundle/ruby/1.9.1/gems/roomorama_api-0.3.0/lib/roomorama_api.rb:43:in `puts'
...
```

As a fix, i propose to introduce debug mode (off by default) and use that condition to log debug stuff.

Also I've added _User Agent_ header to Faraday requests.
